### PR TITLE
fix: Render empty string when notification time is not present (In case of no notifications message)

### DIFF
--- a/src/views/user/NotificationPage.vue
+++ b/src/views/user/NotificationPage.vue
@@ -54,7 +54,7 @@ onIonViewWillEnter(async () => {
               </div>
 
               <span class="body-small notification-time">{{
-                `${formatDate(notification.time, "D MMM")} at ${formatDate(notification.time, "h:mm A")}`
+                notification.time ? `${formatDate(notification.time, "D MMM")} at ${formatDate(notification.time, "h:mm A")}` : ""
               }}</span>
             </div>
             <p class="body-medium notification-content">


### PR DESCRIPTION
Before: 
![image](https://github.com/user-attachments/assets/6645c2dd-9d13-4941-9ed3-ed9899cf93ec)

After:
![image](https://github.com/user-attachments/assets/54ba8842-d7d7-48c8-a8ac-17399c8e206a)
