### PR TITLE
feat: add production deployment workflow (WI-001002)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -20,7 +20,7 @@ jobs:
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ secrets.PRODUCTION_HOST }}
-          username: ${{ secrets.USERNAME }}
+          username: ${{ secrets.PRODUCTION_USERNAME }}
           key: ${{ secrets.PRODUCTION_KEY }}
           port: 22
           command_timeout: 30m

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,29 @@
+name: Deploy to Production
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - version-15
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Deploy to Production
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.PRODUCTION_HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PRODUCTION_KEY }}
+          port: 22
+          command_timeout: 30m
+          script_stop: true
+          script: |
+            set -x
+            cd /home/frappe/mobile_app_ionic
+            git pull upstream version-15
+            yarn install
+            yarn build

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - version-15
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -22,8 +26,10 @@ jobs:
           command_timeout: 30m
           script_stop: true
           script: |
-            set -x
+            set -euxo pipefail
             cd /home/frappe/mobile_app_ionic
-            git pull upstream version-15
-            yarn install
+            git fetch upstream version-15
+            git checkout version-15
+            git reset --hard upstream/version-15
+            yarn install --frozen-lockfile
             yarn build


### PR DESCRIPTION
Adds deploy-production.yml that:
- Triggers on push to version-15 and manual workflow_dispatch
- SSHs into production server via appleboy/ssh-action (pinned v1.2.5)
- Pulls latest from upstream version-15
- Runs yarn install + yarn build
- Uses PRODUCTION_HOST/PRODUCTION_KEY secrets
- Follows established patterns from other apps (script_stop, command_timeout, set -x)

## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch tested?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
