### PR TITLE
fix: replace webfont service icons with tree-shakeable SVG component

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@ionic/vue": "^7.0.0",
     "@ionic/vue-router": "^7.0.0",
     "@mdi/font": "^7.4.47",
+    "@mdi/js": "^7.4.47",
     "@popperjs/core": "^2.11.8",
     "axios": "^1.6.8",
     "dayjs": "^1.11.10",

--- a/src/components/base/MdiIcon.vue
+++ b/src/components/base/MdiIcon.vue
@@ -1,0 +1,244 @@
+<template>
+  <svg
+    v-if="resolvedPath"
+    viewBox="0 0 24 24"
+    :width="size"
+    :height="size"
+    role="img"
+    aria-hidden="true"
+    class="mdi-svg-icon"
+  >
+    <path :d="resolvedPath" fill="currentColor" />
+  </svg>
+  <!-- Fallback: renders nothing (keeps layout) if icon not found -->
+  <span v-else class="mdi-svg-icon mdi-svg-icon--missing" :style="{ width: size + 'px', height: size + 'px' }" />
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+/**
+ * MdiIcon — A tree-shakeable SVG icon component.
+ *
+ * Instead of loading the entire ~240 KB @mdi/font webfont,
+ * this component accepts an SVG path directly OR resolves
+ * a kebab-case icon name from a curated map.
+ *
+ * Usage:
+ *   <MdiIcon name="clock-outline" />
+ *   <MdiIcon :path="mdiClockOutline" />
+ */
+
+// Import ONLY the specific icons used by the app's services.
+// Each import is ~200 bytes vs the full 240 KB font.
+// Add new icons here as the API introduces new services.
+import {
+  mdiClockOutline,
+  mdiCalendar,
+  mdiCalendarMonth,
+  mdiCalendarCheck,
+  mdiCalendarMinus,
+  mdiCalendarClock,
+  mdiFileDocument,
+  mdiFileDocumentOutline,
+  mdiFileDocumentEditOutline,
+  mdiFileUndoOutline,
+  mdiAccountClock,
+  mdiAccountClockOutline,
+  mdiAccountGroup,
+  mdiAccountCheck,
+  mdiMapMarker,
+  mdiMapMarkerOutline,
+  mdiCheckCircle,
+  mdiCheckCircleOutline,
+  mdiClipboardText,
+  mdiClipboardTextOutline,
+  mdiClipboardCheck,
+  mdiClipboardCheckOutline,
+  mdiBriefcase,
+  mdiBriefcaseOutline,
+  mdiCog,
+  mdiCogOutline,
+  mdiBell,
+  mdiBellOutline,
+  mdiHome,
+  mdiHomeOutline,
+  mdiLogout,
+  mdiLogin,
+  mdiPencil,
+  mdiPencilCircleOutline,
+  mdiPlus,
+  mdiClose,
+  mdiChevronDown,
+  mdiChevronRight,
+  mdiArrowRight,
+  mdiEye,
+  mdiEyeOutline,
+  mdiEyeCheckOutline,
+  mdiFilter,
+  mdiFilterOutline,
+  mdiMagnify,
+  mdiDotsVertical,
+  mdiInformation,
+  mdiInformationOutline,
+  mdiAlert,
+  mdiAlertOutline,
+  mdiShieldCheck,
+  mdiShieldCheckOutline,
+  mdiHammer,
+  mdiWrench,
+  mdiTools,
+  mdiHandshake,
+  mdiHandshakeOutline,
+  mdiFolderOpen,
+  mdiFolderOpenOutline,
+  mdiCurrencyUsd,
+  mdiCash,
+  mdiCashMultiple,
+  mdiStar,
+  mdiStarOutline,
+  mdiHeart,
+  mdiHeartOutline,
+  mdiFlag,
+  mdiFlagOutline,
+  mdiBook,
+  mdiBookOutline,
+  mdiSchool,
+  mdiHardHat,
+  mdiFireExtinguisher,
+  mdiSecurity,
+  mdiDomain,
+  mdiOfficeBuildingOutline,
+  mdiOfficeBuilding,
+  mdiTruck,
+  mdiTruckOutline,
+  mdiPhone,
+  mdiPhoneOutline,
+  mdiEmail,
+  mdiEmailOutline,
+  mdiMapMarkerDistance,
+  mdiSwapHorizontalCircle,
+  mdiCalendarRange,
+  mdiPackageVariant,
+} from '@mdi/js'
+
+// Map from kebab-case icon name (as returned by the API) to SVG path data.
+// The key format matches what the API sends in `service_icon` / `icon` fields.
+const iconMap = {
+  'clock-outline': mdiClockOutline,
+  'calendar': mdiCalendar,
+  'calendar-month': mdiCalendarMonth,
+  'calendar-check': mdiCalendarCheck,
+  'calendar-minus': mdiCalendarMinus,
+  'calendar-clock': mdiCalendarClock,
+  'file-document': mdiFileDocument,
+  'file-document-outline': mdiFileDocumentOutline,
+  'file-document-edit-outline': mdiFileDocumentEditOutline,
+  'file-undo-outline': mdiFileUndoOutline,
+  'account-clock': mdiAccountClock,
+  'account-clock-outline': mdiAccountClockOutline,
+  'account-group': mdiAccountGroup,
+  'account-check': mdiAccountCheck,
+  'map-marker': mdiMapMarker,
+  'map-marker-outline': mdiMapMarkerOutline,
+  'check-circle': mdiCheckCircle,
+  'check-circle-outline': mdiCheckCircleOutline,
+  'clipboard-text': mdiClipboardText,
+  'clipboard-text-outline': mdiClipboardTextOutline,
+  'clipboard-check': mdiClipboardCheck,
+  'clipboard-check-outline': mdiClipboardCheckOutline,
+  'briefcase': mdiBriefcase,
+  'briefcase-outline': mdiBriefcaseOutline,
+  'cog': mdiCog,
+  'cog-outline': mdiCogOutline,
+  'bell': mdiBell,
+  'bell-outline': mdiBellOutline,
+  'home': mdiHome,
+  'home-outline': mdiHomeOutline,
+  'logout': mdiLogout,
+  'login': mdiLogin,
+  'pencil': mdiPencil,
+  'pencil-circle-outline': mdiPencilCircleOutline,
+  'plus': mdiPlus,
+  'close': mdiClose,
+  'chevron-down': mdiChevronDown,
+  'chevron-right': mdiChevronRight,
+  'arrow-right': mdiArrowRight,
+  'eye': mdiEye,
+  'eye-outline': mdiEyeOutline,
+  'eye-check-outline': mdiEyeCheckOutline,
+  'filter': mdiFilter,
+  'filter-outline': mdiFilterOutline,
+  'magnify': mdiMagnify,
+  'dots-vertical': mdiDotsVertical,
+  'information': mdiInformation,
+  'information-outline': mdiInformationOutline,
+  'alert': mdiAlert,
+  'alert-outline': mdiAlertOutline,
+  'shield-check': mdiShieldCheck,
+  'shield-check-outline': mdiShieldCheckOutline,
+  'hammer': mdiHammer,
+  'wrench': mdiWrench,
+  'tools': mdiTools,
+  'handshake': mdiHandshake,
+  'handshake-outline': mdiHandshakeOutline,
+  'folder-open': mdiFolderOpen,
+  'folder-open-outline': mdiFolderOpenOutline,
+  'currency-usd': mdiCurrencyUsd,
+  'cash': mdiCash,
+  'cash-multiple': mdiCashMultiple,
+  'star': mdiStar,
+  'star-outline': mdiStarOutline,
+  'heart': mdiHeart,
+  'heart-outline': mdiHeartOutline,
+  'flag': mdiFlag,
+  'flag-outline': mdiFlagOutline,
+  'book': mdiBook,
+  'book-outline': mdiBookOutline,
+  'school': mdiSchool,
+  'hard-hat': mdiHardHat,
+  'fire-extinguisher': mdiFireExtinguisher,
+  'security': mdiSecurity,
+  'domain': mdiDomain,
+  'office-building-outline': mdiOfficeBuildingOutline,
+  'office-building': mdiOfficeBuilding,
+  'truck': mdiTruck,
+  'truck-outline': mdiTruckOutline,
+  'phone': mdiPhone,
+  'phone-outline': mdiPhoneOutline,
+  'email': mdiEmail,
+  'email-outline': mdiEmailOutline,
+  'swap_horizontal_circle': mdiSwapHorizontalCircle,
+  'calendar-range': mdiCalendarRange,
+  'inventory_2': mdiPackageVariant,
+}
+
+const props = defineProps({
+  /** Direct SVG path data string (takes priority over `name`) */
+  path: { type: String, default: '' },
+  /** Kebab-case icon name matching the API's service_icon field, e.g. "clock-outline" */
+  name: { type: String, default: '' },
+  /** Icon size in pixels */
+  size: { type: [String, Number], default: 24 },
+})
+
+const resolvedPath = computed(() => {
+  if (props.path) return props.path
+  if (props.name && iconMap[props.name]) return iconMap[props.name]
+  if (props.name) {
+    console.warn(`[MdiIcon] Unknown icon name: "${props.name}". Add it to the iconMap in MdiIcon.vue.`)
+  }
+  return null
+})
+</script>
+
+<style scoped>
+.mdi-svg-icon {
+  display: inline-block;
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+.mdi-svg-icon--missing {
+  display: inline-block;
+}
+</style>

--- a/src/components/service/GroupCard.vue
+++ b/src/components/service/GroupCard.vue
@@ -9,6 +9,7 @@ import {
   IonText,
 } from "@ionic/vue";
 import IconChevronDown from "@/components/icon/ChevronDown.vue";
+import MdiIcon from "@/components/base/MdiIcon.vue";
 
 const props = defineProps({
   serviceGroup: {
@@ -65,10 +66,11 @@ watch(
         @click="showContent = !showContent"
       >
         <div class="group-card-title-wrapper">
-          <span
-            class="mdi group-card-title-icon"
-            :class="`mdi-${serviceGroup.icon}`"
-          ></span>
+          <MdiIcon
+            :name="serviceGroup.icon"
+            :size="24"
+            class="group-card-title-icon"
+          />
           <ion-text>
             <p class="group-card-title">{{ serviceGroup.name }}</p>
           </ion-text>
@@ -87,7 +89,7 @@ watch(
               @click="$emit('open-service', service.name)"
             >
               <div class="services-item-icon-wrapper">
-                <span class="mdi" :class="`mdi-${service.icon}`" />
+                <MdiIcon :name="service.icon" :size="24" />
               </div>
               <p class="services-item-label">
                 {{ service.name }}

--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,7 @@ import VCalendar from "v-calendar";
 
 /* Core CSS required for Ionic components to work properly */
 import "@ionic/vue/css/core.css";
-import "@mdi/font/css/materialdesignicons.css";
+// REMOVED: @mdi/font webfont (~240 KB). Replaced by tree-shakeable MdiIcon.vue component using @mdi/js.
 
 /* Basic CSS for apps built with Ionic */
 import "@ionic/vue/css/normalize.css";

--- a/src/views/user/HomePage.vue
+++ b/src/views/user/HomePage.vue
@@ -10,6 +10,7 @@ import configuration from "@/api/configuration";
 import { useCustomToast } from "@/composable/toast";
 import { ref, computed } from "vue";
 import Header from "@/components/Header.vue";
+import MdiIcon from "@/components/base/MdiIcon.vue";
 import { getServiceRoute } from "@/utils/serviceRouteMap";
 
 const router = useIonRouter();
@@ -68,7 +69,7 @@ onIonViewDidEnter(() => {
           @click="goToServicePage(service.service)"
         >
           <div class="services-item-icon-wrapper">
-            <span class="mdi" :class="`mdi-${service.service_icon}`" />
+            <MdiIcon :name="service.service_icon" :size="24" />
           </div>
           <div class="services-item-label">
             {{ $i18n.locale === 'ar' ? service.service_ar : service.service }}


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
Service icons on the Home and Service pages render as blank boxes in production (e.g. the eye icon for Checkin Checkout, calendar icon for Leaves).

## Solution description
Icons were rendered via `<span class="mdi mdi-{icon}" />`, which depends on the ~240 KB `@mdi/font` webfont loading successfully. If that font fails to load for any reason, every icon silently renders as an empty box -- no error, just missing glyphs.

Replaced with `MdiIcon.vue`, a small component resolving an icon name to an inline SVG path from `@mdi/js`. No external font file involved, so it can't silently fail to load.

This is scoped to *only* the icon-rendering fix (cherry-picked out of a larger existing commit on `staging` that bundled it with unrelated auth/localization work). It does not include any other pending `staging` changes.

## Areas affected and ensured
- `package.json` (add `@mdi/js` dependency)
- `src/components/base/MdiIcon.vue` (new component)
- `src/views/user/HomePage.vue` (icon usage)
- `src/components/service/GroupCard.vue` (icon usage, both group and service-item icons)
- `src/main.js` (drop the `@mdi/font` webfont import)

## Is there any existing behavior change of other features due to this code change?
No. Purely visual (icon rendering), same icon names/data from the backend.

## Did you test with the following dataset?
- [x] Existing Data

## Which browser(s) did you use for testing?
- [x] Chrome

Verified with a production build (`yarn build`) -- compiles clean, no errors.